### PR TITLE
refactor: recreate devcontainer according to the open devcontainer specification

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,6 @@
 	// See complete list https://mcr.microsoft.com/v2/devcontainers/base/tags/list
 	"image": "mcr.microsoft.com/devcontainers/base:dev-bullseye",
 	
-	"containerEnv": {
-		"LANG":"en_US.UTF-8",
-		"LANGUAGE":"en_US:en",
-		"TZ":"Etc/UTC",
-		"LC_ALL":"en_US.UTF-8"
-	},
-	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
 		// Jekyll server
@@ -17,10 +10,11 @@
 		// Live reload server
 		35729
 	],
-
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode",
-
+	
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "root",
+	
+	// Add more features. See complete list https://github.com/devcontainers/features
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
 			"moby": false,
@@ -33,6 +27,14 @@
 			"version": "2.7.4" 
 		}
 	},
+	
+	"containerEnv": {
+		"LANG":"en_US.UTF-8",
+		"LANGUAGE":"en_US:en",
+		"TZ":"Etc/UTC",
+		"LC_ALL":"en_US.UTF-8"
+	},
+
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
 	"name": "GitHub Pages (Jekyll)",
 	// See complete list https://mcr.microsoft.com/v2/devcontainers/base/tags/list
 	"image": "mcr.microsoft.com/devcontainers/base:dev-bullseye",
-	"hostRequirements": {
-		"memory": "4gb"
-	},
+	// "hostRequirements": {
+	// 	"memory": "2gb"
+	// },
 	"containerEnv": {
 		"LANG":"en_US.UTF-8",
 		"LANGUAGE":"en_US:en",
@@ -24,14 +24,9 @@
 	],
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode",
+	// "remoteUser": "vscode",
 
 	"features": {
-		"ghcr.io/devcontainers/features/common-utils:2": {
-			"username": "vscode",
-			"configureZshAsDefaultShell": true,
-			"installOhMyZsh": false
-		},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
 			"moby": false,
 			"dockerDashComposeVersion": "v2" 
@@ -73,8 +68,5 @@
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// Fix for Omnisharp analyzer fail
-	// Read more https://github.com/OmniSharp/omnisharp-vscode/issues/3143#issuecomment-513501863
-	"postCreateCommand": "zsh .devcontainer/post-create.zsh",
-	// "overrideCommand": false,
+	"postCreateCommand": "zsh .devcontainer/post-create.zsh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
 	"name": "GitHub Pages (Jekyll)",
-	"image": "mcr.microsoft.com/vscode/devcontainers/base:dev-bullseye",
-
+	// See complete list https://mcr.microsoft.com/v2/devcontainers/base/tags/list
+	"image": "mcr.microsoft.com/devcontainers/base:dev-bullseye",
+	"hostRequirements": {
+		"memory": "4gb"
+	},
 	"containerEnv": {
 		"LANG":"en_US.UTF-8",
 		"LANGUAGE":"en_US:en",
@@ -9,8 +12,8 @@
 		"LC_ALL":"en_US.UTF-8"
 	},
 
-    "workspaceMount": "src=${localWorkspaceFolder},dst=/workspace,type=bind,consistency=cached",
-	"workspaceFolder": "/workspace",
+    // "workspaceMount": "src=${localWorkspaceFolder},dst=/workspace,type=bind,consistency=cached",
+	// "workspaceFolder": "/workspace",
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
@@ -20,57 +23,58 @@
 		35729
 	],
 
-	"features": {
-		"common": {
-			"username": "automatic",
-			"uid": "automatic",
-			"gid": "automatic",
-			"installZsh": true,
-			"upgradePackages": true
-		},
-		// GitHub Pages dependencies https://pages.github.com/versions/
-		"ruby": "2.7.4",
-		"node": {
-			"version": "lts",
-        	"nodeGypDependencies": true
-		},
-		"docker-from-docker": {
-			"version": "latest",
-			"moby": false,
-			"dockerDashComposeVersion": "v2"
-		},
-		"github-cli": "latest"
-	},
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.defaultProfile.linux": "zsh",
-		"editor.formatOnPaste": true,
-		"editor.guides.bracketPairs": "active",
-		"debug.internalConsoleOptions": "neverOpen",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
 
-		"files.watcherExclude": {
-			"**/_site/**": true
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"username": "vscode",
+			"configureZshAsDefaultShell": true,
+			"installOhMyZsh": false
+		},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"moby": false,
+			"dockerDashComposeVersion": "v2" 
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/node:1": {},
+		// GitHub Pages dependencies https://pages.github.com/versions/
+		"ghcr.io/devcontainers/features/ruby:1": { 
+			"version": "2.7.4" 
 		}
 	},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [		
-		"ms-vscode.wordcount",
-		"editorconfig.editorconfig",
-		"esbenp.prettier-vscode",
-		"streetsidesoftware.code-spell-checker",
-        "znck.grammarly",
-		"redhat.fabric8-analytics",
-		"redhat.vscode-yaml",
-		"bierner.github-markdown-preview"
-	],
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-vscode.wordcount",
+				"editorconfig.editorconfig",
+				"esbenp.prettier-vscode",
+				"streetsidesoftware.code-spell-checker",
+				"znck.grammarly",
+				"redhat.fabric8-analytics",
+				"redhat.vscode-yaml",
+				"bierner.github-markdown-preview",
+				"rebornix.Ruby"
+			],
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"terminal.integrated.defaultProfile.linux": "zsh",
+				"editor.formatOnPaste": true,
+				"editor.guides.bracketPairs": "active",
+				"debug.internalConsoleOptions": "neverOpen",
+				"files.watcherExclude": {
+					"**/_site/**": true
+				}
+			}
+		}
+	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// Fix for Omnisharp analyzer fail
 	// Read more https://github.com/OmniSharp/omnisharp-vscode/issues/3143#issuecomment-513501863
 	"postCreateCommand": "zsh .devcontainer/post-create.zsh",
 	// "overrideCommand": false,
-	
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,18 +2,13 @@
 	"name": "GitHub Pages (Jekyll)",
 	// See complete list https://mcr.microsoft.com/v2/devcontainers/base/tags/list
 	"image": "mcr.microsoft.com/devcontainers/base:dev-bullseye",
-	// "hostRequirements": {
-	// 	"memory": "2gb"
-	// },
+	
 	"containerEnv": {
 		"LANG":"en_US.UTF-8",
 		"LANGUAGE":"en_US:en",
 		"TZ":"Etc/UTC",
 		"LC_ALL":"en_US.UTF-8"
 	},
-
-    // "workspaceMount": "src=${localWorkspaceFolder},dst=/workspace,type=bind,consistency=cached",
-	// "workspaceFolder": "/workspace",
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [


### PR DESCRIPTION
this changeset is to replace the current devcontainer with the modern open dev container specification and templates.

- replace .devcontainer content according to @devcontainers/features
- remove commonutil feature due to remote user conflict when installing node feature
- enable root user to run container as root
- add inline documentation and links to issues
- clean up